### PR TITLE
Move `facetedValue` into `FacetedChart`. Create `CompositeChart` from `FacetedChart` and new `NestedChart`

### DIFF
--- a/src/Adapters/README.md
+++ b/src/Adapters/README.md
@@ -1,58 +1,29 @@
 # Deconstructing Visualizations
 
-The adapter pattern is at the core in the design of Olli, being used to deconstruct visualizations into a VisualizationStructure object. Since every visualization grammar contains its own complexities, in order to make a wider set of visualizations accessible, adapters are used to create a common object that can then be rendered into different accessible formats. Generating a screen-reader accessible structure for multiple visualization libraries is streamlined as the rendering no longer has to work with the concrete implementation of external libraries. The type system is comprised of a primary VisualizationStructure describing the structure of a chart with Guides. The types bring out the perceived or hierarchical elements of a chart that are rarely explicitely outlined in a specificatio
+The adapter pattern is at the core in the design of Olli, being used to deconstruct visualizations
+into an `OlliVisSpec`. Since every visualization grammar contains its own
+complexities, in order to make a wider set of visualizations accessible, adapters are used to create
+a common type that can then be rendered into different accessible formats. Generating a
+screen-reader accessible structure for multiple visualization libraries is streamlined as the
+rendering no longer has to work with the concrete implementation of external libraries. The type
+system is comprised of a primary `OlliVisSpec` describing the structure of a chart with
+`Guide`s. The types bring out the perceived or hierarchical elements of a chart that are rarely
+explicitly outlined in a specification.
 
-## `VisualizationStructure`
+## `OlliVisSpec`
 
-The VisualizationStructure is the output of the adapters deconstructing a visualization from its original specification into a more generalized format. A Visualization will either be a faceted view of nested charts or simply be a single chart depending on the hierarchy of information. Each object also contains a high-level description of the visualization and the data that being visualized. Within a lone chart, the VisualizationStructure also outlines the structured elements of the chart including axes and legend, but also visual information such as the mark being used and the title of the chart, if any.
+The `OlliVisSpec` is the output of the adapters deconstructing a visualization from its original
+specification into a more generalized format. A visualization will either be a composite view of
+nested charts or simply be a single chart depending on the hierarchy of information. Each object
+also contains a high-level description of the visualization and the data that being visualized.
+Within a lone chart, the `OlliVisSpec` also outlines the structured elements of the chart
+including axes and legend, but also visual information such as the mark being used and the title of
+the chart, if any.
 
-Interface for the base `VisualizationInformation`:
+Specific type information may be found in `Types.ts`.
 
-```js
-type AbstractedVis = {
-    description: string,
-    data: Map<string, any[]>,
-    dataFieldsUsed: string[],
-}
-```
+### `Guide`s
 
-Interface for `ChartInformation`:
+`Guide`s contain information on the structured elements of charts. The axes and legends of a visualization share many common attributes throughout visualization grammars, and Olli reflects those similarities.
 
-```js
-interface ChartInformation extends AbstractedVis {
-    axes: Axis[] ,
-    legends: Legend[],
-    description: string,
-    gridNodes: Guide[],
-    dataFieldsUsed: string[],
-    markUsed?: Mark,
-    title? : string
-    facetedValue?: any
-}
-```
-
-Interface for `FacetedChart`:
-
-```js
-interface FacetedChart extends AbstractedVis {
-    charts: ChartInformation[],
-    facetedField: string
-}
-```
-
-### `Guides`
-
-Guides contain information on the structured elements of charts. The axes and legends of a visualization share many common attributes throughout visualization grammars, and Olli reflects those similarities.
-
-Interface for `Guides`:
-
-```js
-type Guide = {
-    values: string[] | number[]
-    title: string
-    data: any[]
-    field: string | string[],
-    markUsed?: Mark,
-    scaleType?: string
-}
-```
+The `Guide` type may also be found in `Types.ts`.

--- a/src/Adapters/Types.ts
+++ b/src/Adapters/Types.ts
@@ -30,7 +30,7 @@ export type Mark = "point" | "bar" | "rect" | "line" | "geoshape" | "circle" | "
 }
 
 /**
- * plots that masy have multiple charts contained within a single specification
+ * plots that may have multiple charts contained within a single specification
  */
 export interface FacetedChart extends BaseOlliVisSpec {
     type: "facetedChart",

--- a/src/Adapters/Types.ts
+++ b/src/Adapters/Types.ts
@@ -41,7 +41,6 @@ export interface FacetedChart extends BaseOlliVisSpec {
 
 export interface NestedChart extends BaseOlliVisSpec {
     type: "nestedChart",
-    // maps faceted value to chart
     charts: Chart[],
 }
 

--- a/src/Adapters/Types.ts
+++ b/src/Adapters/Types.ts
@@ -8,6 +8,7 @@ export type Mark = "point" | "bar" | "rect" | "line" | "geoshape" | "circle" | "
  * later be used to create an explorable Accessibility Tree.
  */
  type BaseOlliVisSpec = {
+    type: string,
     description: string,
     data: any[],
     dataFieldsUsed: string[],
@@ -18,6 +19,7 @@ export type Mark = "point" | "bar" | "rect" | "line" | "geoshape" | "circle" | "
  * Outlines the grammar of graphics information that has to be parsed from a visualization.
  */
  export interface Chart extends BaseOlliVisSpec {
+    type: "chart",
     axes: Axis[] ,
     legends: Legend[],
     description: string,
@@ -32,19 +34,12 @@ export type Mark = "point" | "bar" | "rect" | "line" | "geoshape" | "circle" | "
  * plots that masy have multiple charts contained within a single specification
  */
 export interface FacetedChart extends BaseOlliVisSpec {
+    type: "facetedChart",
     charts: Chart[],
     facetedField: string
 }
 
 export type OlliVisSpec = Chart | FacetedChart;
-
-export const isChart = (olliVisSpec: OlliVisSpec): olliVisSpec is Chart => {
-    return Boolean((olliVisSpec as Chart).axes && (olliVisSpec as Chart).legends);
-}
-
-export const isFacetedChart = (olliVisSpec: OlliVisSpec): olliVisSpec is FacetedChart => {
-    return Boolean((olliVisSpec as FacetedChart).facetedField);
-}
 
 /**
  * The {@link Guide} is an the information needed for generating various nodes on the Accessibility Tree where

--- a/src/Adapters/Types.ts
+++ b/src/Adapters/Types.ts
@@ -27,7 +27,6 @@ export type Mark = "point" | "bar" | "rect" | "line" | "geoshape" | "circle" | "
     dataFieldsUsed: string[],
     markUsed?: Mark,
     title? : string
-    facetedValue?: any
 }
 
 /**
@@ -35,11 +34,20 @@ export type Mark = "point" | "bar" | "rect" | "line" | "geoshape" | "circle" | "
  */
 export interface FacetedChart extends BaseOlliVisSpec {
     type: "facetedChart",
-    charts: Chart[],
+    // maps faceted value to chart
+    charts: Map<any, Chart>,
     facetedField: string
 }
 
-export type OlliVisSpec = Chart | FacetedChart;
+export interface NestedChart extends BaseOlliVisSpec {
+    type: "nestedChart",
+    // maps faceted value to chart
+    charts: Chart[],
+}
+
+export type CompositeChart = FacetedChart | NestedChart;
+
+export type OlliVisSpec = Chart | CompositeChart;
 
 export const chart = (fields: Omit<Chart, 'type'>): Chart => {
     return { ...fields, type: "chart" }
@@ -47,6 +55,10 @@ export const chart = (fields: Omit<Chart, 'type'>): Chart => {
 
 export const facetedChart = (fields: Omit<FacetedChart, 'type'>): FacetedChart => {
     return { ...fields, type: "facetedChart" }
+}
+
+export const nestedChart = (fields: Omit<NestedChart, 'type'>): NestedChart => {
+    return { ...fields, type: "nestedChart" }
 }
 
 /**

--- a/src/Adapters/Types.ts
+++ b/src/Adapters/Types.ts
@@ -41,6 +41,14 @@ export interface FacetedChart extends BaseOlliVisSpec {
 
 export type OlliVisSpec = Chart | FacetedChart;
 
+export const chart = (fields: Omit<Chart, 'type'>): Chart => {
+    return { ...fields, type: "chart" }
+}
+
+export const facetedChart = (fields: Omit<FacetedChart, 'type'>): FacetedChart => {
+    return { ...fields, type: "facetedChart" }
+}
+
 /**
  * The {@link Guide} is an the information needed for generating various nodes on the Accessibility Tree where
  *   values: is the array of values on the data source (ex: tick values for an Axis)

--- a/src/Adapters/VegaAdapter.ts
+++ b/src/Adapters/VegaAdapter.ts
@@ -1,5 +1,5 @@
 import { Spec, ScaleDataRef, Scale, ScaleData, Scene } from "vega";
-import { Guide, OlliVisSpec, VisAdapter, FacetedChart, Chart, Axis, Legend, facetedChart } from "./Types";
+import { Guide, OlliVisSpec, VisAdapter, FacetedChart, Chart, Axis, Legend, facetedChart, nestedChart, NestedChart } from "./Types";
 
 let view: any;
 let spec: Spec;
@@ -21,7 +21,7 @@ export const VegaAdapter: VisAdapter = (visObject: Scene, helperVisInformation: 
         }
     }
 
-function parseMultiViewChart(): FacetedChart {
+function parseMultiViewChart(): NestedChart {
     const filterUniqueNodes = ((nodeArr: any[]) => {
         let uniqueNodes: any[] = []
         nodeArr.forEach((node: any) => {
@@ -43,12 +43,11 @@ function parseMultiViewChart(): FacetedChart {
         return chart
     })
 
-    let multiViewChart = facetedChart({
+    let multiViewChart = nestedChart({
         charts: charts,
         data: getData(),
         dataFieldsUsed: getDataFields(axes, legends),
         description: baseVisDescription,
-        facetedField: ""
     })
 
     const shallowCopyArray = (objToCopy: any[], arrToPush: any[]): void => {

--- a/src/Adapters/VegaAdapter.ts
+++ b/src/Adapters/VegaAdapter.ts
@@ -1,5 +1,5 @@
 import { Spec, ScaleDataRef, Scale, ScaleData, Scene } from "vega";
-import { Guide, OlliVisSpec, VisAdapter, FacetedChart, Chart, Axis, Legend } from "./Types";
+import { Guide, OlliVisSpec, VisAdapter, FacetedChart, Chart, Axis, Legend, facetedChart } from "./Types";
 
 let view: any;
 let spec: Spec;
@@ -43,13 +43,13 @@ function parseMultiViewChart(): FacetedChart {
         return chart
     })
 
-    let multiViewChart = {
+    let multiViewChart = facetedChart({
         charts: charts,
         data: getData(),
         dataFieldsUsed: getDataFields(axes, legends),
         description: baseVisDescription,
         facetedField: ""
-    }
+    })
 
     const shallowCopyArray = (objToCopy: any[], arrToPush: any[]): void => {
         objToCopy.forEach((obj: any) => {
@@ -77,14 +77,14 @@ function parseSingleChart(chart: any): Chart {
     const chartTitle: string | null = findScenegraphNodes(chart, "title")[0] !== undefined ?
         findScenegraphNodes(chart, "title")[0].items[0].items[0].items[0].text
         : null;
-    let chartNode: Chart = {
+    let chartNode = chart({
         data: data,
         axes: axes,
         legends: legends,
         description: baseVisDescription,
         gridNodes: gridNodes,
         dataFieldsUsed: dataFields
-    }
+    })
     if (chartTitle) {
         chartNode.title = chartTitle;
     }

--- a/src/Adapters/VegaLiteAdapter.ts
+++ b/src/Adapters/VegaLiteAdapter.ts
@@ -8,7 +8,9 @@ import {
     Guide,
     FacetedChart,
     Axis,
-    Legend
+    Legend,
+    facetedChart,
+    chart
 } from "./Types";
 
 /**
@@ -63,13 +65,13 @@ function parseMultiView(scenegraph: any, spec: any): OlliVisSpec {
             return chartData
         });
 
-    let node: FacetedChart = {
+    let node = facetedChart({
         description: "",
         data: getVisualizationData(scenegraph, spec),
         dataFieldsUsed: fields,
         charts: nestedHeirarchies,
         facetedField: facetedField
-    }
+    })
 
     node.dataFieldsUsed.push(facetedField)
     node.charts.forEach((chart: Chart) => {
@@ -90,7 +92,7 @@ function parseChart(scenegraph: any, spec: any): Chart {
     let legends: Legend[] = findScenegraphNodes(scenegraph, "legend").map((legend: any) => parseLegend(scenegraph, legend, spec))
     let fields: string[] = (axes as any[]).concat(legends).reduce((fieldArr: string[], guide: Guide) => fieldArr.concat(guide.field), [])
     let mark: Mark = spec.mark
-    let node: Chart = {
+    let node = chart({
         axes: axes.filter((axis: Axis) => axis.field !== undefined),
         legends: legends,
         description: "",
@@ -98,7 +100,7 @@ function parseChart(scenegraph: any, spec: any): Chart {
         gridNodes: [],
         data: getVisualizationData(scenegraph, spec),
         markUsed: mark
-    }
+    })
     constructChartDescription(node, spec);
     modifyVisFromMark(node, mark, spec);
     return node

--- a/src/Structure/index.ts
+++ b/src/Structure/index.ts
@@ -1,4 +1,4 @@
-import { Guide, Chart, FacetedChart, OlliVisSpec, isFacetedChart, isChart } from "../Adapters/Types";
+import { Guide, Chart, FacetedChart, OlliVisSpec } from "../Adapters/Types";
 import { AccessibilityTreeNode, NodeType } from "./Types";
 import { Mark } from '../Adapters/Types'
 
@@ -9,7 +9,7 @@ import { Mark } from '../Adapters/Types'
  */
 export function olliVisSpecToTree(olliVisSpec: OlliVisSpec): AccessibilityTreeNode {
     let node: AccessibilityTreeNode;
-    if (isFacetedChart(olliVisSpec)) {
+    if (olliVisSpec.type === "facetedChart") {
         node = informationToNode(olliVisSpec.description, null, olliVisSpec.data, "multiView", olliVisSpec);
         node.description += ` With ${node.children.length} nested charts`
     } else {

--- a/src/Structure/index.ts
+++ b/src/Structure/index.ts
@@ -1,15 +1,15 @@
-import { Guide, Chart, FacetedChart, OlliVisSpec } from "../Adapters/Types";
+import { Guide, Chart, CompositeChart, OlliVisSpec } from "../Adapters/Types";
 import { AccessibilityTreeNode, NodeType } from "./Types";
 import { Mark } from '../Adapters/Types'
 
 /**
  * Constructs an {@link AccessibilityTreeNode} based off of a generalized visualization
- * @param olliVisSpec the {@link Chart} or {@link FacetedChart} to transform into a tree
+ * @param olliVisSpec the {@link Chart} or {@link CompositeChart} to transform into a tree
  * @returns The transormed {@link AccessibilityTreeNode}
  */
 export function olliVisSpecToTree(olliVisSpec: OlliVisSpec): AccessibilityTreeNode {
     let node: AccessibilityTreeNode;
-    if (olliVisSpec.type === "facetedChart") {
+    if (olliVisSpec.type === "facetedChart" || olliVisSpec.type === "nestedChart") {
         node = informationToNode(olliVisSpec.description, null, olliVisSpec.data, "multiView", olliVisSpec);
         node.description += ` With ${node.children.length} nested charts`
     } else {
@@ -27,13 +27,23 @@ export function olliVisSpecToTree(olliVisSpec: OlliVisSpec): AccessibilityTreeNo
  * @param multiViewChart The {@link FacetedChart} of the abstracted visualization
  * @returns an array of {@link AccessibilityTreeNode} to be the given parent's children
  */
-function generateMultiViewChildren(parent: AccessibilityTreeNode, multiViewChart: FacetedChart): AccessibilityTreeNode[] {
-    return multiViewChart.charts.map((singleChart: Chart) => informationToNode(
-        `A facet titled ${singleChart.facetedValue}, ${multiViewChart.charts.indexOf(singleChart) + 1} of ${multiViewChart.charts.length}`,
-        parent,
-        [],
-        "chart",
-        singleChart));
+function generateMultiViewChildren(parent: AccessibilityTreeNode, multiViewChart: CompositeChart): AccessibilityTreeNode[] {
+    if (multiViewChart.type === "facetedChart") {
+        return Object.entries(multiViewChart.charts).map(([facetedValue, singleChart]: [any, Chart], i) => informationToNode(
+            `A facet titled ${facetedValue}, ${i + 1} of ${multiViewChart.charts.size}`,
+            parent,
+            [],
+            "chart",
+            singleChart));
+    } else {
+        // if (multiViewChart.type === "nestedChart")
+        return multiViewChart.charts.map((singleChart: Chart, i) => informationToNode(
+            `A nested chart ${singleChart.title ? `titled ${singleChart.title}` : ''}, ${i + 1} of ${multiViewChart.charts.length}`,
+            parent,
+            [],
+            "chart",
+            singleChart));
+    }
 }
 
 /**


### PR DESCRIPTION
There was previously a strong coupling between faceting and unit charts, so I moved the faceting field into the facet chart type.

While I was doing that I realized that sometimes we are constructed a nested chart with no known faceting field. In this case there wasn't a faceted value so I was forced to handle this case explicitly (b/c in the new type there is a map where the faceted value must exist). So I decided to split off a new nested chart type.

This has the benefit of providing more precise descriptions based on whether or not there is a facet involved.

Definitely need to test this change, because the test suite is broken locally even on current main. It does typecheck though.