### PR TITLE
Layer & concat multi-view support + TimeUnit support

### DIFF
--- a/docs/_data/examples.json
+++ b/docs/_data/examples.json
@@ -123,6 +123,16 @@
       }
     ]
   },
+  "concat_chart": {
+    "title": "Concatenated Chart",
+    "url": "/gallery/concat.html",
+    "adapters": [
+      {
+        "name": "Vega-Lite",
+        "code": "/examples/concatChart-vl.html"
+      }
+    ]
+  },
   "aggregate_bar_chart": {
     "title": "Aggregate Bar Chart",
     "url": "/gallery/aggregateBarChart.html",

--- a/docs/_data/examples.json
+++ b/docs/_data/examples.json
@@ -1,4 +1,4 @@
-{ 
+{
   "bar_chart": {
     "title": "Bar Chart",
     "img": "/img/barChart.JPG",
@@ -110,6 +110,16 @@
       {
         "name": "ObservablePlot",
         "code": "/examples/facetedChart-op.html"
+      }
+    ]
+  },
+  "layered_chart": {
+    "title": "Layered Chart",
+    "url": "/gallery/layer.html",
+    "adapters": [
+      {
+        "name": "Vega-Lite",
+        "code": "/examples/layeredChart-vl.html"
       }
     ]
   },
@@ -232,7 +242,7 @@
         "code": "/examples/steamgraph-vl.html"
       }
     ]
-  }, 
+  },
   "heatmap": {
     "title": "Heatmap",
     "url": "/gallery/heatmap.html",

--- a/docs/_includes/examples/aggregateBarChart-vl.html
+++ b/docs/_includes/examples/aggregateBarChart-vl.html
@@ -1,21 +1,23 @@
 <script type="module">
   let spec = {
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-    "description": "A bar chart showing the US population distribution of age groups in 2000.",
-    "data": { "url": "https://raw.githubusercontent.com/vega/vega-datasets/next/data/population.json" },
+    "data": { "url": "https://raw.githubusercontent.com/vega/vega-datasets/next/data/seattle-weather.csv" },
     "mark": "bar",
     "encoding": {
       "x": {
-        "aggregate": "sum", "field": "people",
-        "title": "population"
+        "timeUnit": "month",
+        "field": "date",
+        "type": "ordinal"
+
       },
       "y": {
-        "field": "age"
-      },
+        "aggregate": "mean",
+        "field": "precipitation",
+        "type": "quantitative"
+      }
     }
   }
-  
-  
+
   let vegaSpec = vegaLite.compile(spec).spec
   const runtime = vega.parse(vegaSpec);
   const vegaRender = document.getElementById('Visualization-Vega-Lite');

--- a/docs/_includes/examples/areaChart-vl.html
+++ b/docs/_includes/examples/areaChart-vl.html
@@ -1,18 +1,18 @@
 <script type="module">
 let spec = {
   "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-  "description": "Google's stock price over time.",
-  "data": { "url": "https://raw.githubusercontent.com/vega/vega-datasets/next/data/stocks.csv" },
-  "mark": {"type": "area", "line": true, "point": true},
+  "description": "Unemployment across industries.",
+  "data": { "url": "https://raw.githubusercontent.com/vega/vega-datasets/next/data/unemployment-across-industries.json" },
+  "mark": "area",
   "encoding": {
     "x": {
-      "field": "date", 
-      "type": "temporal"
+      "timeUnit": "yearmonth", "field": "date",
+      "axis": {"format": "%Y"}
     },
     "y": {
-      "field": "price", 
-      "type": "quantitative"
-    },
+      "aggregate": "sum", "field": "count",
+      "title": "count"
+    }
   }
 }
 

--- a/docs/_includes/examples/concatChart-vl.html
+++ b/docs/_includes/examples/concatChart-vl.html
@@ -1,0 +1,63 @@
+<script type="module">
+  let spec = {
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+    "description": "Two vertically concatenated charts that show a histogram of precipitation in Seattle and the relationship between min and max temperature.",
+    "data": {
+      "url": "https://raw.githubusercontent.com/vega/vega-datasets/next/data/weather.csv"
+    },
+    "transform": [{
+      "filter": "datum.location === 'Seattle'"
+    }],
+    "vconcat": [
+      {
+        "mark": "bar",
+        "encoding": {
+          "x": {
+            "timeUnit": "month",
+            "field": "date",
+            "type": "ordinal"
+          },
+          "y": {
+            "aggregate": "mean",
+            "field": "precipitation",
+            "type": "quantitative"
+          }
+        }
+      },
+      {
+        "mark": "point",
+        "encoding": {
+          "x": {
+            "field": "temp_min",
+            "type": "quantitative",
+            "bin": true
+          },
+          "y": {
+            "field": "temp_max",
+            "type": "quantitative",
+            "bin": true
+          },
+          "size": {
+            "aggregate": "count",
+            "type": "quantitative"
+          }
+        }
+      }
+    ]
+  }
+
+  let vegaSpec = vegaLite.compile(spec).spec
+  const runtime = vega.parse(vegaSpec);
+  const vegaRender = document.getElementById('Visualization-Vega-Lite');
+  let view = new vega.View(runtime)
+    .logLevel(vega.Warn)
+    .initialize(vegaRender)
+    .renderer('svg')
+    .hover()
+    .runAsync()
+    .then(v => {
+      OlliAdapters.VegaLiteAdapter(spec).then(olliVisSpec => {
+        document.getElementById("AccessibilityTree-Vega-Lite").append(olli(olliVisSpec))
+      })
+    });
+</script>

--- a/docs/_includes/examples/layeredChart-vl.html
+++ b/docs/_includes/examples/layeredChart-vl.html
@@ -1,0 +1,36 @@
+<script type="module">
+  let spec = {
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+    "description": "Plot showing average data with raw values in the background.",
+    "data": { "url": "https://raw.githubusercontent.com/vega/vega-datasets/next/data/stocks.csv" },
+    "transform": [{"filter": "datum.symbol==='GOOG'"}],
+    "layer": [{
+      "mark": {"type": "point", "opacity": 0.3},
+      "encoding": {
+        "x": {"timeUnit":"year", "field": "date"},
+        "y": {"field": "price", "type": "quantitative"}
+      }
+    }, {
+      "mark": "line",
+      "encoding": {
+        "x": {"timeUnit":"year", "field": "date"},
+        "y": {"aggregate": "mean", "field": "price"}
+      }
+    }]
+  }
+
+  let vegaSpec = vegaLite.compile(spec).spec
+  const runtime = vega.parse(vegaSpec);
+  const vegaRender = document.getElementById('Visualization-Vega-Lite');
+  let view = new vega.View(runtime)
+    .logLevel(vega.Warn)
+    .initialize(vegaRender)
+    .renderer('svg')
+    .hover()
+    .runAsync()
+    .then(v => {
+      OlliAdapters.VegaLiteAdapter(spec).then(olliVisSpec => {
+        document.getElementById("AccessibilityTree-Vega-Lite").append(olli(olliVisSpec))
+      })
+    });
+</script>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -59,6 +59,7 @@ title: "Examples"
     </li>
     <ul>
       <li> <a href="{{site.baseurl}}/gallery/facet.html">Faceted Charts</a></li>
+      <li> <a href="{{site.baseurl}}/gallery/layer.html">Layered Charts</a></li>
     </ul>
   </ul>
 </div>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -60,6 +60,7 @@ title: "Examples"
     <ul>
       <li> <a href="{{site.baseurl}}/gallery/facet.html">Faceted Charts</a></li>
       <li> <a href="{{site.baseurl}}/gallery/layer.html">Layered Charts</a></li>
+      <li> <a href="{{site.baseurl}}/gallery/concat.html">Concatenated Charts</a></li>
     </ul>
   </ul>
 </div>

--- a/docs/gallery/concat.html
+++ b/docs/gallery/concat.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: "Concatenated Chart Example"
+---
+
+{% assign chart=site.data.examples["concat_chart"] %}
+{% include example.html content=chart %}

--- a/docs/gallery/layer.html
+++ b/docs/gallery/layer.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: "Layered Chart Example"
+---
+
+{% assign chart=site.data.examples["layered_chart"] %}
+{% include example.html content=chart %}

--- a/packages/adapters/src/ObservablePlotAdapter.ts
+++ b/packages/adapters/src/ObservablePlotAdapter.ts
@@ -1,4 +1,4 @@
-import { VisAdapter, OlliSpec, OlliAxis, OlliLegend, OlliMark } from 'olli';
+import { VisAdapter, UnitOlliSpec, OlliAxis, OlliLegend, OlliMark } from 'olli';
 
 // Observable-Plot has no type declaration file :/
 const Plot = require('@observablehq/plot');
@@ -15,7 +15,7 @@ type ObservablePlotSpec = any;
  */
 export const ObservablePlotAdapter: VisAdapter<ObservablePlotSpec> = async (
   plotObject: ObservablePlotSpec
-): Promise<OlliSpec> => {
+): Promise<UnitOlliSpec> => {
   const plotSVG = await Plot.plot(plotObject);
   const description = plotObject.ariaDescription;
   return plotToOlliSpec(plotObject, plotSVG, description);
@@ -27,7 +27,7 @@ export const ObservablePlotAdapter: VisAdapter<ObservablePlotSpec> = async (
  * @param svg the rendered SVGElement of the visualization
  * @returns the generated {@link FacetedChart}
  */
-function plotToOlliSpec(plot: any, svg: Element, description?: string): OlliSpec {
+function plotToOlliSpec(plot: any, svg: Element, description?: string): UnitOlliSpec {
   const chartSVG = svg.tagName !== 'svg' ? Object.values(svg.children).find((n) => n.tagName === 'svg')! : svg;
   const axes: OlliAxis[] = ['x-axis', 'y-axis'].reduce((parsedAxes: OlliAxis[], s: string) => {
     let axisSVG = findHtmlElement(chartSVG, s);

--- a/packages/adapters/src/VegaAdapter.ts
+++ b/packages/adapters/src/VegaAdapter.ts
@@ -9,7 +9,7 @@ import {
   SceneGroup,
   SignalRef,
 } from 'vega';
-import { OlliSpec, VisAdapter, OlliMark, OlliDataset, OlliAxis, OlliLegend } from 'olli';
+import { UnitOlliSpec, VisAdapter, OlliMark, OlliDataset, OlliAxis, OlliLegend } from 'olli';
 import { filterUniqueObjects, findScenegraphNodes, getData, getVegaScene, getVegaView } from './utils';
 
 /**
@@ -18,7 +18,7 @@ import { filterUniqueObjects, findScenegraphNodes, getData, getVegaScene, getVeg
  * @returns the {@link OlliVisSpec}, the non-concrete visualization information that can be later used to
  * generate the Accessibility Tree Encoding
  */
-export const VegaAdapter: VisAdapter<Spec> = async (spec: Spec): Promise<OlliSpec> => {
+export const VegaAdapter: VisAdapter<Spec> = async (spec: Spec): Promise<UnitOlliSpec> => {
   const scene: SceneGroup = getVegaScene(await getVegaView(spec));
   const data = getData(scene)[0];
   const description = spec.description; // possible text description included with spec
@@ -29,7 +29,7 @@ export const VegaAdapter: VisAdapter<Spec> = async (spec: Spec): Promise<OlliSpe
   }
 };
 
-function parseFacets(spec: Spec, scene: SceneGroup, data: OlliDataset): OlliSpec {
+function parseFacets(spec: Spec, scene: SceneGroup, data: OlliDataset): UnitOlliSpec {
   const axes = filterUniqueObjects<OlliAxis>(
     findScenegraphNodes(scene, 'axis').map((axisNode: any) => parseAxisInformation(spec, axisNode, data))
   );
@@ -58,7 +58,7 @@ function parseFacets(spec: Spec, scene: SceneGroup, data: OlliDataset): OlliSpec
   };
 }
 
-function parseSingleChart(spec: Spec, scene: Scene | SceneItem, data: OlliDataset): OlliSpec {
+function parseSingleChart(spec: Spec, scene: Scene | SceneItem, data: OlliDataset): UnitOlliSpec {
   const axes = findScenegraphNodes(scene, 'axis').map((axisNode: any) => parseAxisInformation(spec, axisNode, data));
   const legends = findScenegraphNodes(scene, 'legend').map((legendNode: any) =>
     parseLegendInformation(spec, legendNode, data)

--- a/packages/adapters/src/VegaAdapter.ts
+++ b/packages/adapters/src/VegaAdapter.ts
@@ -20,7 +20,7 @@ import { filterUniqueObjects, findScenegraphNodes, getData, getVegaScene, getVeg
  */
 export const VegaAdapter: VisAdapter<Spec> = async (spec: Spec): Promise<OlliSpec> => {
   const scene: SceneGroup = getVegaScene(await getVegaView(spec));
-  const data = getData(scene);
+  const data = getData(scene)[0];
   const description = spec.description; // possible text description included with spec
   if (scene.items.some((el: any) => el.role === 'scope')) {
     return { description, ...parseFacets(spec, scene, data) };

--- a/packages/adapters/src/VegaLiteAdapter.ts
+++ b/packages/adapters/src/VegaLiteAdapter.ts
@@ -30,7 +30,7 @@ export const VegaLiteAdapter: VisAdapter<TopLevelSpec> = async (spec: TopLevelSp
 
 const getFieldFromEncoding = (encoding) => {
   if ('aggregate' in encoding) {
-    if (encoding.field === undefined) {
+    if (encoding.aggregate === 'count') {
       return `__${encoding.aggregate}`;
     }
     return `${encoding.aggregate}_${encoding.field}`;

--- a/packages/adapters/src/VegaLiteAdapter.ts
+++ b/packages/adapters/src/VegaLiteAdapter.ts
@@ -1,6 +1,8 @@
 import { TopLevelSpec, compile } from 'vega-lite';
-import { VisAdapter, OlliSpec, OlliNode, typeInference } from 'olli';
+import { VisAdapter, UnitOlliSpec, typeInference, OlliSpec, OlliDataset } from 'olli';
 import { getData, getVegaScene, getVegaView } from './utils';
+import { TopLevelUnitSpec } from 'vega-lite/build/src/spec/unit';
+import { TopLevel, LayerSpec } from 'vega-lite/build/src/spec';
 
 /**
  * Adapter to deconstruct Vega-Lite visualizations into an {@link OlliVisSpec}
@@ -11,118 +13,156 @@ export const VegaLiteAdapter: VisAdapter<TopLevelSpec> = async (spec: TopLevelSp
   const view = await getVegaView(compile(spec).spec);
   const scene = getVegaScene(view);
   const data = getData(scene);
-  const description = spec.description; // possible text description included with spec
-  const olliSpec: OlliSpec = {
-    description,
-    data: data[0],
+
+  if ('mark' in spec) {
+    return adaptUnitSpec(spec, data[0]);
+  } else {
+    // TODO: handle layer and concat specs
+    if ('layer' in spec) {
+      return await adaptLayerSpec(spec, data);
+    } else if ('concat' in spec || 'hconcat' in spec || 'vconcat' in spec) {
+      // TODO: concat specs
+    } else {
+      // TODO: other specs?
+    }
+  }
+};
+
+const getFieldFromEncoding = (encoding) => {
+  if ('aggregate' in encoding) {
+    if (encoding.field === undefined) {
+      return `__${encoding.aggregate}`;
+    }
+    return `${encoding.aggregate}_${encoding.field}`;
+  }
+  if ('timeUnit' in encoding) {
+    return `${encoding.timeUnit}_${encoding.field}`;
+  }
+
+  return 'condition' in encoding ? encoding.condition.field : encoding.field;
+};
+
+const typeCoerceData = (olliSpec: UnitOlliSpec) => {
+  olliSpec.fields.forEach((fieldDef) => {
+    if (fieldDef.type === 'temporal') {
+      // convert temporal data into Date objects
+      olliSpec.data.forEach((datum) => {
+        datum[fieldDef.field] = new Date(datum[fieldDef.field]);
+      });
+    }
+  });
+};
+
+function adaptUnitSpec(spec: TopLevelUnitSpec<any>, data: OlliDataset): UnitOlliSpec {
+  // unit spec
+  const olliSpec: UnitOlliSpec = {
+    description: spec.description,
+    data: data,
     fields: [],
     axes: [],
     legends: [],
   };
 
-  if ('mark' in spec) {
-    // unit spec
-
-    const getMark = (spec: any) => {
-      // TODO vega-lite mark type exceeds olli mark type, should do some validation
-      const mark: any = spec.mark;
-      if (mark && mark.type) {
-        // e.g. "mark": {"type": "line", "point": true}
-        return mark.type;
-      }
-      return mark;
-    };
-    olliSpec.mark = getMark(spec);
-
-    const getFieldFromEncoding = (encoding) => {
-      if ('aggregate' in encoding) {
-        if (encoding.field === undefined) {
-          return `__${encoding.aggregate}`;
-        }
-        return `${encoding.aggregate}_${encoding.field}`;
-      }
-
-      return 'condition' in encoding ? encoding.condition.field : encoding.field;
-    };
-
-    if (spec.encoding) {
-      Object.entries(spec.encoding).forEach(([channel, encoding]) => {
-        const fieldDef = { ...encoding };
-        fieldDef.field = getFieldFromEncoding(encoding);
-        fieldDef.type =
-          encoding.type || (encoding.timeUnit ? 'temporal' : false) || typeInference(data[0], fieldDef.field);
-
-        if (!fieldDef.field) {
-          return;
-        }
-        if (['row', 'column', 'facet'].includes(channel)) {
-          // add facet field
-          olliSpec.facet = fieldDef.field;
-        } else if (olliSpec.mark === 'line' && ['color', 'detail'].includes(channel)) {
-          // treat multi-series line charts as facets
-          olliSpec.facet = fieldDef.field;
-        } else if (['x', 'y'].includes(channel)) {
-          // add axes
-          olliSpec.axes.push({
-            axisType: channel as 'x' | 'y',
-            field: fieldDef.field,
-            title: encoding.title,
-          });
-        } else if (['color', 'opacity'].includes(channel)) {
-          // add legends
-          olliSpec.legends.push({
-            channel: channel as any,
-            field: fieldDef.field,
-            title: encoding.title,
-          });
-        } else {
-          // TODO: handle other channels
-          return;
-        }
-
-        // add field to list of field defs
-        if (!olliSpec.fields.find((f) => f.field === fieldDef.field)) {
-          olliSpec.fields.push(fieldDef);
-        }
-      });
+  const getMark = (spec: any) => {
+    // TODO vega-lite mark type exceeds olli mark type, should do some validation
+    const mark: any = spec.mark;
+    if (mark && mark.type) {
+      // e.g. "mark": {"type": "line", "point": true}
+      return mark.type;
     }
-  } else {
-    // TODO: handle layer and concat specs
-    if ('layer' in spec) {
-      await Promise.all(
-        spec.layer.map(async (layer) => {
-          if ('mark' in layer) {
-            // unit layer
-            const layerSpec = {
-              data: layer.data || spec.data,
-              mark: layer.mark,
-              encoding: layer.encoding,
-            };
-            const layerOlliSpec = await VegaLiteAdapter(layerSpec);
-            olliSpec.fields.push(...layerOlliSpec.fields);
-            olliSpec.axes.push(...layerOlliSpec.axes);
-            olliSpec.legends.push(...layerOlliSpec.legends);
-          } else {
-            // nested layer
-          }
-        })
-      );
-      olliSpec.fields = olliSpec.fields.filter((f, i, self) => self.findIndex((f2) => f2.field === f.field) === i);
-      olliSpec.axes = olliSpec.axes.filter((f, i, self) => self.findIndex((f2) => f2.field === f.field) === i);
-      olliSpec.legends = olliSpec.legends.filter((f, i, self) => self.findIndex((f2) => f2.field === f.field) === i);
-    }
+    return mark;
+  };
+  olliSpec.mark = getMark(spec);
+
+  if (spec.encoding) {
+    Object.entries(spec.encoding).forEach(([channel, encoding]) => {
+      const fieldDef = { ...encoding };
+      fieldDef.field = getFieldFromEncoding(encoding);
+      fieldDef.type = encoding.type || (encoding.timeUnit ? 'temporal' : false) || typeInference(data, fieldDef.field);
+
+      if (!fieldDef.field) {
+        return;
+      }
+      if (['row', 'column', 'facet'].includes(channel)) {
+        // add facet field
+        olliSpec.facet = fieldDef.field;
+      } else if (olliSpec.mark === 'line' && ['color', 'detail'].includes(channel)) {
+        // treat multi-series line charts as facets
+        olliSpec.facet = fieldDef.field;
+      } else if (['x', 'y'].includes(channel)) {
+        // add axes
+        olliSpec.axes.push({
+          axisType: channel as 'x' | 'y',
+          field: fieldDef.field,
+          title: encoding.title,
+        });
+      } else if (['color', 'opacity'].includes(channel)) {
+        // add legends
+        olliSpec.legends.push({
+          channel: channel as any,
+          field: fieldDef.field,
+          title: encoding.title,
+        });
+      } else {
+        // TODO: handle other channels
+        return;
+      }
+
+      // add field to list of field defs
+      if (!olliSpec.fields.find((f) => f.field === fieldDef.field)) {
+        olliSpec.fields.push(fieldDef);
+      }
+    });
   }
 
-  olliSpec.fields.forEach((fieldDef) => {
-    if (fieldDef.type === 'temporal') {
-      // convert temporal data into Date objects
-      data.forEach((datum) => {
-        datum[fieldDef.field] = new Date(datum[fieldDef.field]);
-      });
-    }
-  });
-
-  console.log(olliSpec);
+  typeCoerceData(olliSpec);
 
   return olliSpec;
-};
+}
+
+async function adaptLayerSpec(spec: TopLevel<LayerSpec<any>>, data: OlliDataset[]): Promise<UnitOlliSpec[]> {
+  const olliSpec: UnitOlliSpec[] = data.map((d) => {
+    return {
+      description: spec.description,
+      data: d,
+      fields: [],
+      axes: [],
+      legends: [],
+    };
+  });
+
+  await Promise.all(
+    spec.layer.map(async (layer) => {
+      if ('mark' in layer) {
+        // unit layer
+        const layerSpec = {
+          data: layer.data || spec.data,
+          mark: layer.mark,
+          encoding: layer.encoding,
+        };
+        const dataset = data.find((d) => {
+          const fields = Object.keys(d[0]);
+          const layerFields = Object.values(layerSpec.encoding).map((f) => getFieldFromEncoding(f));
+          return layerFields.every((f) => fields.includes(f));
+        });
+        const layerOlliSpec = adaptUnitSpec(layerSpec, dataset);
+        const unitSpec = olliSpec.find((s) => Object.keys(s.data[0]).every((k) => dataset[0][k]));
+        unitSpec?.fields.push(...layerOlliSpec.fields);
+        unitSpec?.axes.push(...layerOlliSpec.axes);
+        unitSpec?.legends.push(...layerOlliSpec.legends);
+      } else {
+        // TODO: nested layer
+      }
+    })
+  );
+
+  olliSpec.forEach((s) => {
+    s.fields = s.fields.filter((f, i, self) => self.findIndex((f2) => f2.field === f.field) === i);
+    s.axes = s.axes.filter((f, i, self) => self.findIndex((f2) => f2.field === f.field) === i);
+    s.legends = s.legends.filter((f, i, self) => self.findIndex((f2) => f2.field === f.field) === i);
+
+    typeCoerceData(s);
+  });
+
+  return olliSpec;
+}

--- a/packages/adapters/src/VegaLiteAdapter.ts
+++ b/packages/adapters/src/VegaLiteAdapter.ts
@@ -142,7 +142,9 @@ async function adaptLayerSpec(spec: TopLevel<LayerSpec<any>>, data: OlliDataset[
         };
         const dataset = data.find((d) => {
           const fields = Object.keys(d[0]);
-          const layerFields = Object.values(layerSpec.encoding).map((f) => getFieldFromEncoding(f));
+          const layerFields = Object.values(layerSpec.encoding)
+            .map((f) => getFieldFromEncoding(f))
+            .filter((f) => f);
           return layerFields.every((f) => fields.includes(f));
         });
         const layerOlliSpec = adaptUnitSpec(layerSpec, dataset);
@@ -164,6 +166,10 @@ async function adaptLayerSpec(spec: TopLevel<LayerSpec<any>>, data: OlliDataset[
 
     typeCoerceData(s);
   });
+
+  if (olliSpec.length === 1) {
+    return olliSpec[0];
+  }
 
   return olliSpec;
 }

--- a/packages/adapters/src/VegaLiteAdapter.ts
+++ b/packages/adapters/src/VegaLiteAdapter.ts
@@ -150,6 +150,7 @@ async function adaptLayerSpec(spec: TopLevel<LayerSpec<any>>, data: OlliDataset[
         unitSpec?.fields.push(...layerOlliSpec.fields);
         unitSpec?.axes.push(...layerOlliSpec.axes);
         unitSpec?.legends.push(...layerOlliSpec.legends);
+        unitSpec.mark = layerOlliSpec.mark;
       } else {
         // TODO: nested layer
       }

--- a/packages/adapters/src/VegaLiteAdapter.ts
+++ b/packages/adapters/src/VegaLiteAdapter.ts
@@ -93,7 +93,7 @@ function adaptUnitSpec(spec: TopLevelUnitSpec<any>, data: OlliDataset): UnitOlli
           field: fieldDef.field,
           title: encoding.title,
         });
-      } else if (['color', 'opacity'].includes(channel)) {
+      } else if (['color', 'opacity', 'size'].includes(channel)) {
         // add legends
         olliSpec.legends.push({
           channel: channel as any,

--- a/packages/adapters/src/utils.ts
+++ b/packages/adapters/src/utils.ts
@@ -62,15 +62,24 @@ function verifyNode(scenegraphNode: any, cancelRoles: string[]): boolean {
   }
 }
 
-export function getData(scene: SceneGroup): OlliDataset {
+export function getData(scene: SceneGroup): OlliDataset[] {
   try {
     const datasets = (scene as any).context.data;
-    const names = Object.keys(datasets).filter((name) => {
-      return name.match(/(source)|(data)_\d/);
+    const data_n = Object.keys(datasets).filter((name) => {
+      return name.match(/data_\d/);
     });
-    const name = names.reverse()[0]; // TODO do we know this is the right one?
-    const dataset = datasets[name].values.value;
-    return dataset;
+    if (data_n.length) {
+      return data_n.map((name) => {
+        return datasets[name].values.value;
+      });
+    } else {
+      const source_n = Object.keys(datasets).filter((name) => {
+        return name.match(/source_\d/);
+      });
+      const name = source_n[source_n.length - 1];
+      const dataset = datasets[name].values.value;
+      return [dataset];
+    }
   } catch (error) {
     throw new Error(`No data found in the Vega scenegraph \n ${error}`);
   }

--- a/packages/adapters/src/utils.ts
+++ b/packages/adapters/src/utils.ts
@@ -71,7 +71,7 @@ export function getData(scene: SceneGroup): OlliDataset[] {
     if (data_n.length) {
       return data_n
         .map((name) => {
-          return datasets[name].values.value;
+          return datasets[name].values.value as OlliDataset;
         })
         .filter((d, idx, self) => {
           if (!d.length) {
@@ -80,14 +80,16 @@ export function getData(scene: SceneGroup): OlliDataset[] {
           if (Object.keys(d[0]).length === 0) {
             return false;
           }
-          return self.findLastIndex((d2) => Object.keys(d2[0]).every((k) => Object.keys(d[0]).includes(k))) === idx;
+          return (
+            (self as any).findLastIndex((d2) => Object.keys(d2[0]).every((k) => Object.keys(d[0]).includes(k))) === idx
+          );
         });
     } else {
       const data_n = Object.keys(datasets).filter((name) => {
         return name.match(/(source)|(data)_\d/);
       });
       const name = data_n[data_n.length - 1];
-      const dataset = datasets[name].values.value;
+      const dataset = datasets[name].values.value as OlliDataset;
       return [dataset];
     }
   } catch (error) {

--- a/packages/adapters/src/utils.ts
+++ b/packages/adapters/src/utils.ts
@@ -69,14 +69,24 @@ export function getData(scene: SceneGroup): OlliDataset[] {
       return name.match(/data_\d/);
     });
     if (data_n.length) {
-      return data_n.map((name) => {
-        return datasets[name].values.value;
-      });
+      return data_n
+        .map((name) => {
+          return datasets[name].values.value;
+        })
+        .filter((d, idx, self) => {
+          if (!d.length) {
+            return false;
+          }
+          if (Object.keys(d[0]).length === 0) {
+            return false;
+          }
+          return self.findLastIndex((d2) => Object.keys(d2[0]).every((k) => Object.keys(d[0]).includes(k))) === idx;
+        });
     } else {
-      const source_n = Object.keys(datasets).filter((name) => {
-        return name.match(/source_\d/);
+      const data_n = Object.keys(datasets).filter((name) => {
+        return name.match(/(source)|(data)_\d/);
       });
-      const name = source_n[source_n.length - 1];
+      const name = data_n[data_n.length - 1];
       const dataset = datasets[name].values.value;
       return [dataset];
     }

--- a/packages/core/src/Customization/index.ts
+++ b/packages/core/src/Customization/index.ts
@@ -112,17 +112,17 @@ export function nodeToDescription(
           return `a ${chartType()}`;
         }
         if (node.children.length) {
-          if (node.children[0].viewOp === 'layer') {
+          if (node.children[0].viewType === 'layer') {
             return 'a layered chart';
           }
-          if (node.children[0].viewOp === 'concat') {
+          if (node.children[0].viewType === 'concat') {
             return 'a multi-view chart';
           }
         }
         return 'a dataset';
       case 'view':
         const viewName =
-          olliSpec.mark === 'line' ? 'line' : olliSpec.mark ? chartType() : node.viewOp ? node.viewOp : 'view';
+          olliSpec.mark === 'line' ? 'line' : olliSpec.mark ? chartType() : node.viewType ? node.viewType : 'view';
         return `a ${viewName}`;
       case 'xAxis':
       case 'yAxis':

--- a/packages/core/src/Customization/index.ts
+++ b/packages/core/src/Customization/index.ts
@@ -76,8 +76,7 @@ export function nodeToDescription(
           return olliSpec.description || '';
         }
         return '';
-      case 'layer':
-      case 'facet':
+      case 'view':
         if ('predicate' in node && 'equal' in node.predicate) {
           return `titled ${node.predicate.equal}`;
         }
@@ -94,8 +93,7 @@ export function nodeToDescription(
 
   function index(node: ElaboratedOlliNode): string {
     switch (node.nodeType) {
-      case 'layer':
-      case 'facet':
+      case 'view':
       case 'filteredData':
       case 'other':
         return indexStr;
@@ -113,16 +111,19 @@ export function nodeToDescription(
         if (olliSpec.mark) {
           return `a ${chartType()}`;
         }
-        if (node.children.length && node.children[0].nodeType === 'layer') {
-          return 'a layered chart';
+        if (node.children.length) {
+          if (node.children[0].viewOp === 'layer') {
+            return 'a layered chart';
+          }
+          if (node.children[0].viewOp === 'concat') {
+            return 'a multi-view chart';
+          }
         }
         return 'a dataset';
-      case 'layer':
-        const layerName = olliSpec.mark === 'line' ? 'line' : olliSpec.mark ? chartType() : 'layer';
-        return `a ${layerName}`;
-      case 'facet':
-        const facetName = olliSpec.mark === 'line' ? 'line' : olliSpec.mark ? chartType() : 'facet';
-        return `a ${facetName}`;
+      case 'view':
+        const viewName =
+          olliSpec.mark === 'line' ? 'line' : olliSpec.mark ? chartType() : node.viewOp ? node.viewOp : 'view';
+        return `a ${viewName}`;
       case 'xAxis':
       case 'yAxis':
       case 'legend':
@@ -158,8 +159,7 @@ export function nodeToDescription(
           return ' ' + [...fields].join(', ');
         }
         return '';
-      case 'layer':
-      case 'facet':
+      case 'view':
         return `with axes ${axes}`;
       default:
         throw `Node type ${node.nodeType} does not have the 'children' token.`;
@@ -247,8 +247,7 @@ export function nodeToDescription(
 
   const nodeTypeToTokens = new Map<OlliNodeType, string[]>([
     ['root', ['name', 'type', 'size', 'children']],
-    ['facet', ['index', 'type', 'name', 'children']],
-    ['layer', ['index', 'type', 'name', 'children']],
+    ['view', ['index', 'type', 'name', 'children']],
     ['xAxis', ['name', 'type', 'data']],
     ['yAxis', ['name', 'type', 'data']],
     ['legend', ['name', 'type', 'data']],

--- a/packages/core/src/Customization/index.ts
+++ b/packages/core/src/Customization/index.ts
@@ -1,5 +1,5 @@
 import { OlliDataset, OlliValue } from '../Types';
-import { OlliSpec } from '../Types';
+import { UnitOlliSpec } from '../Types';
 import { ElaboratedOlliNode, OlliNodeType } from '../Structure/Types';
 import { getBins } from '../util/bin';
 import { getDomain, getFieldDef } from '../util/data';
@@ -32,7 +32,7 @@ export function getCustomizedDescription(node: ElaboratedOlliNode) {
 export function nodeToDescription(
   node: ElaboratedOlliNode,
   dataset: OlliDataset,
-  olliSpec: OlliSpec
+  olliSpec: UnitOlliSpec
 ): Map<string, string> {
   const indexStr = `${(node.parent?.children.indexOf(node) || 0) + 1} of ${(node.parent?.children || []).length}`;
   const description = olliSpec.description || '';

--- a/packages/core/src/Customization/index.ts
+++ b/packages/core/src/Customization/index.ts
@@ -76,6 +76,7 @@ export function nodeToDescription(
           return olliSpec.description || '';
         }
         return '';
+      case 'layer':
       case 'facet':
         if ('predicate' in node && 'equal' in node.predicate) {
           return `titled ${node.predicate.equal}`;
@@ -93,6 +94,7 @@ export function nodeToDescription(
 
   function index(node: ElaboratedOlliNode): string {
     switch (node.nodeType) {
+      case 'layer':
       case 'facet':
       case 'filteredData':
       case 'other':
@@ -111,7 +113,13 @@ export function nodeToDescription(
         if (olliSpec.mark) {
           return `a ${chartType()}`;
         }
+        if (node.children.length && node.children[0].nodeType === 'layer') {
+          return 'a layered chart';
+        }
         return 'a dataset';
+      case 'layer':
+        const layerName = olliSpec.mark === 'line' ? 'line' : olliSpec.mark ? chartType() : 'layer';
+        return `a ${layerName}`;
       case 'facet':
         const facetName = olliSpec.mark === 'line' ? 'line' : olliSpec.mark ? chartType() : 'facet';
         return `a ${facetName}`;
@@ -150,6 +158,7 @@ export function nodeToDescription(
           return ' ' + [...fields].join(', ');
         }
         return '';
+      case 'layer':
       case 'facet':
         return `with axes ${axes}`;
       default:
@@ -181,7 +190,7 @@ export function nodeToDescription(
             if (domain.length) {
               first = fmtValue(domain[0]);
               last = fmtValue(domain[domain.length - 1]);
-              return `with ${pluralize(domain.values.length, 'value')} from ${first} to ${last}`;
+              return `with ${pluralize(domain.length, 'value')} from ${first} to ${last}`;
             }
           }
         }
@@ -239,6 +248,7 @@ export function nodeToDescription(
   const nodeTypeToTokens = new Map<OlliNodeType, string[]>([
     ['root', ['name', 'type', 'size', 'children']],
     ['facet', ['index', 'type', 'name', 'children']],
+    ['layer', ['index', 'type', 'name', 'children']],
     ['xAxis', ['name', 'type', 'data']],
     ['yAxis', ['name', 'type', 'data']],
     ['legend', ['name', 'type', 'data']],

--- a/packages/core/src/Render/Dialog/index.ts
+++ b/packages/core/src/Render/Dialog/index.ts
@@ -97,11 +97,8 @@ function openDialog(dialog: HTMLElement, renderContainer: HTMLElement) {
 
 export function openTableDialog(olliNode: ElaboratedOlliNode, tree: OlliRuntime) {
   const olliSpec = getSpecForNode(olliNode, tree.olliSpec) as UnitOlliSpec;
-  const table = renderTable(
-    selectionTest(olliSpec.data, olliNode.fullPredicate),
-    olliSpec.fields.map((f) => f.field)
-  );
-  const dialog = makeDialog(tree, 'Table View', predicateToDescription(olliNode.fullPredicate), table);
+  const table = renderTable(selectionTest(olliSpec.data, olliNode.fullPredicate), olliSpec.fields);
+  const dialog = makeDialog(tree, 'Table View', predicateToDescription(olliNode.fullPredicate, olliSpec.fields), table);
 
   openDialog(dialog, tree.renderContainer);
 }

--- a/packages/core/src/Render/Dialog/index.ts
+++ b/packages/core/src/Render/Dialog/index.ts
@@ -128,9 +128,7 @@ export function openTargetedNavigationDialog(tree: OlliRuntime) {
 
   const onOk = () => {
     const selectedNodeId = menu.getAttribute('data-state');
-    console.log(selectedNodeId);
     const treeItem = tree.treeItems.find((item) => item.olliNode.id === selectedNodeId);
-    console.log(treeItem);
     if (treeItem) {
       tree.setFocusToItem(treeItem);
     }

--- a/packages/core/src/Render/Dialog/index.ts
+++ b/packages/core/src/Render/Dialog/index.ts
@@ -96,7 +96,7 @@ function openDialog(dialog: HTMLElement, renderContainer: HTMLElement) {
 }
 
 export function openTableDialog(olliNode: ElaboratedOlliNode, tree: OlliRuntime) {
-  const olliSpec = getSpecForNode(olliNode, tree.olliSpec) as UnitOlliSpec;
+  const olliSpec: UnitOlliSpec = getSpecForNode(olliNode, tree.olliSpec);
   const table = renderTable(selectionTest(olliSpec.data, olliNode.fullPredicate), olliSpec.fields);
   const dialog = makeDialog(tree, 'Table View', predicateToDescription(olliNode.fullPredicate, olliSpec.fields), table);
 
@@ -104,7 +104,7 @@ export function openTableDialog(olliNode: ElaboratedOlliNode, tree: OlliRuntime)
 }
 
 export function openSelectionDialog(olliNode: ElaboratedOlliNode, tree: OlliRuntime) {
-  const olliSpec = getSpecForNode(olliNode, tree.olliSpec) as UnitOlliSpec;
+  const olliSpec: UnitOlliSpec = getSpecForNode(olliNode, tree.olliSpec);
   const menu = makeSelectionMenu(olliSpec);
 
   const onOk = () => {

--- a/packages/core/src/Render/Dialog/index.ts
+++ b/packages/core/src/Render/Dialog/index.ts
@@ -1,12 +1,13 @@
 import { predicateToDescription } from '../../Customization';
 import { ElaboratedOlliNode } from '../../Structure/Types';
-import { OlliSpec } from '../../Types';
+import { UnitOlliSpec } from '../../Types';
 import { selectionTest } from '../../util/selection';
 import { renderTable } from '../Table';
 import { OlliRuntime } from '../../Runtime/OlliRuntime';
 import './dialog.css';
 import { makeSelectionMenu } from './selectionMenu';
 import { makeTargetedNavMenu } from './targetedNavMenu';
+import { getSpecForNode } from '../../Structure';
 
 export function makeDialog(
   tree: OlliRuntime,
@@ -95,7 +96,7 @@ function openDialog(dialog: HTMLElement, renderContainer: HTMLElement) {
 }
 
 export function openTableDialog(olliNode: ElaboratedOlliNode, tree: OlliRuntime) {
-  const olliSpec = tree.olliSpec;
+  const olliSpec = getSpecForNode(olliNode, tree.olliSpec) as UnitOlliSpec;
   const table = renderTable(
     selectionTest(olliSpec.data, olliNode.fullPredicate),
     olliSpec.fields.map((f) => f.field)
@@ -105,8 +106,9 @@ export function openTableDialog(olliNode: ElaboratedOlliNode, tree: OlliRuntime)
   openDialog(dialog, tree.renderContainer);
 }
 
-export function openSelectionDialog(tree: OlliRuntime) {
-  const menu = makeSelectionMenu(tree.olliSpec);
+export function openSelectionDialog(olliNode: ElaboratedOlliNode, tree: OlliRuntime) {
+  const olliSpec = getSpecForNode(olliNode, tree.olliSpec) as UnitOlliSpec;
+  const menu = makeSelectionMenu(olliSpec);
 
   const onOk = () => {
     const predicate = { and: JSON.parse(menu.getAttribute('data-state')) };

--- a/packages/core/src/Render/Dialog/selectionMenu.ts
+++ b/packages/core/src/Render/Dialog/selectionMenu.ts
@@ -1,11 +1,11 @@
 import { FieldPredicate } from 'vega-lite/src/predicate';
-import { OlliSpec } from '../../Types';
+import { UnitOlliSpec } from '../../Types';
 import { getDomain, getFieldDef } from '../../util/data';
 import { serializeValue } from '../../util/values';
 
 // this would have been so much easier with some ui framework : \
 
-export function makeSelectionMenu(olliSpec: OlliSpec): HTMLElement {
+export function makeSelectionMenu(olliSpec: UnitOlliSpec): HTMLElement {
   const state: FieldPredicate[] = olliSpec.selection
     ? 'and' in olliSpec.selection
       ? (olliSpec.selection.and as FieldPredicate[])
@@ -90,7 +90,7 @@ function valueToPredicateOp(op) {
   }
 }
 
-function makePredicateContainer(menu: HTMLElement, olliSpec: OlliSpec, state, predicateContainers: HTMLElement[]) {
+function makePredicateContainer(menu: HTMLElement, olliSpec: UnitOlliSpec, state, predicateContainers: HTMLElement[]) {
   const predicateContainer = document.createElement('div');
 
   const fieldSelect = document.createElement('select');
@@ -229,7 +229,7 @@ function makePredicateContainer(menu: HTMLElement, olliSpec: OlliSpec, state, pr
 function setPredicateContainerFromState(
   predicateContainer: HTMLElement,
   predicate: FieldPredicate,
-  olliSpec: OlliSpec
+  olliSpec: UnitOlliSpec
 ) {
   const fieldSelect: HTMLSelectElement = predicateContainer.querySelector('.olli-field-select');
   const opSelect: HTMLSelectElement = predicateContainer.querySelector('.olli-op-select');

--- a/packages/core/src/Render/Dialog/selectionMenu.ts
+++ b/packages/core/src/Render/Dialog/selectionMenu.ts
@@ -139,7 +139,7 @@ function makePredicateContainer(menu: HTMLElement, olliSpec: UnitOlliSpec, state
     const selectedOp = opSelect.value;
     const fieldDef = getFieldDef(selectedField, olliSpec.fields);
     if (selectedOp === '=' && (fieldDef.type === 'nominal' || fieldDef.type === 'ordinal')) {
-      const domain = getDomain(selectedField, olliSpec.data);
+      const domain = getDomain(fieldDef, olliSpec.data);
       const valueSelect = document.createElement('select');
       const valueOptions = domain.map((value) => {
         const option = document.createElement('option');

--- a/packages/core/src/Render/Dialog/targetedNavMenu.ts
+++ b/packages/core/src/Render/Dialog/targetedNavMenu.ts
@@ -1,5 +1,6 @@
 import { getCustomizedDescription } from '../../Customization';
 import { OlliRuntime } from '../../Runtime/OlliRuntime';
+import { getSpecForNode } from '../../Structure';
 import { ElaboratedOlliNode } from '../../Structure/Types';
 import { selectionTest } from '../../util/selection';
 
@@ -11,12 +12,13 @@ export function makeTargetedNavMenu(tree: OlliRuntime): HTMLElement {
     if (!node.children || !node.children.length) {
       return null;
     }
+    const olliSpec = getSpecForNode(node, tree.olliSpec);
     const layerDiv = document.createElement('div');
     const layerChildContainer = document.createElement('div');
     const layerSelect = document.createElement('select');
     const sortedByValueCount = [...node.children].sort((a: ElaboratedOlliNode, b: ElaboratedOlliNode) => {
-      const aCount = selectionTest(tree.olliSpec.data, a.fullPredicate).length;
-      const bCount = selectionTest(tree.olliSpec.data, b.fullPredicate).length;
+      const aCount = selectionTest(olliSpec.data, a.fullPredicate).length;
+      const bCount = selectionTest(olliSpec.data, b.fullPredicate).length;
       return bCount - aCount;
     });
     const layerOptions = sortedByValueCount.map((child) => {

--- a/packages/core/src/Render/Table/index.ts
+++ b/packages/core/src/Render/Table/index.ts
@@ -1,15 +1,15 @@
-import { OlliDataset, OlliDatum } from '../../Types';
+import { OlliDataset, OlliDatum, OlliFieldDef } from '../../Types';
 import { fmtValue } from '../../util/values';
 
-export function renderTable(data: OlliDataset, fields: string[]): HTMLElement {
+export function renderTable(data: OlliDataset, fields: OlliFieldDef[]): HTMLElement {
   const table = document.createElement('table');
   const thead = document.createElement('thead');
   const theadtr = document.createElement('tr');
 
-  fields.forEach((field: string) => {
+  fields.forEach((fieldDef: OlliFieldDef) => {
     const th = document.createElement('th');
     th.setAttribute('scope', 'col');
-    th.innerText = field;
+    th.innerText = fieldDef.field;
     theadtr.appendChild(th);
   });
 
@@ -20,9 +20,9 @@ export function renderTable(data: OlliDataset, fields: string[]): HTMLElement {
 
   data.forEach((data: OlliDatum) => {
     const dataRow = document.createElement('tr');
-    fields.forEach((field: string) => {
+    fields.forEach((fieldDef: OlliFieldDef) => {
       const td = document.createElement('td');
-      td.innerText = fmtValue(data[field]);
+      td.innerText = fmtValue(data[fieldDef.field], fieldDef);
       dataRow.appendChild(td);
     });
     tableBody.appendChild(dataRow);

--- a/packages/core/src/Runtime/OlliRuntime.ts
+++ b/packages/core/src/Runtime/OlliRuntime.ts
@@ -1,10 +1,10 @@
 // Adapted from: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/examples/treeview-1b/
 import { ElaboratedOlliNode, OlliNodeLookup } from '../Structure/Types';
 import { OlliNodeType } from '../Structure/Types';
-import { OlliSpec } from '../Types';
+import { OlliSpec, UnitOlliSpec } from '../Types';
 import { setOlliGlobalState } from '../util/globalState';
 import { OlliRuntimeTreeItem } from './OlliRuntimeTreeItem';
-import { olliSpecToTree, treeToNodeLookup } from '../Structure';
+import { getSpecForNode, olliSpecToTree, treeToNodeLookup } from '../Structure';
 import { getCustomizedDescription } from '../Customization';
 import { renderTree } from '../Render/TreeView';
 import { LogicalAnd, LogicalComposition } from 'vega-lite/src/logical';
@@ -76,7 +76,9 @@ export class OlliRuntime {
 
     findTreeitems(this.rootDomNode, this, this.olliNodeLookup, undefined);
 
-    this.rootTreeItem = this.treeItems[0];
+    debugger;
+
+    this.rootTreeItem = this.treeItems.find((ti) => ti.olliNode.nodeType === 'root')!;
     this.rootTreeItem.domNode.tabIndex = 0;
   }
 
@@ -100,7 +102,8 @@ export class OlliRuntime {
 
   setSelection(selection: LogicalAnd<FieldPredicate> | FieldPredicate) {
     const lastNode = this.lastFocusedTreeItem?.olliNode;
-    this.olliSpec.selection = selection;
+    const spec = getSpecForNode(lastNode, this.olliSpec);
+    spec.selection = selection;
     this.init();
     if (lastNode) {
       // find the nearest node to the last selected node and set focus to it
@@ -113,9 +116,9 @@ export class OlliRuntime {
           this.setFocusToItem(item || this.rootTreeItem);
         } else if ('predicate' in lastNode) {
           const pitems = items.filter((ti) => 'predicate' in ti.olliNode);
-          const lastNodeSelection = selectionTest(this.olliSpec.data, { and: [selection, lastNode.predicate] });
+          const lastNodeSelection = selectionTest(spec.data, { and: [selection, lastNode.predicate] });
           const item = pitems.find((ti) => {
-            const tiSelection = selectionTest(this.olliSpec.data, { and: [selection, ti.olliNode.predicate] });
+            const tiSelection = selectionTest(spec.data, { and: [selection, ti.olliNode.predicate] });
             return tiSelection.some((d) => lastNodeSelection.includes(d));
           });
           this.setFocusToItem(item || this.rootTreeItem);

--- a/packages/core/src/Runtime/OlliRuntime.ts
+++ b/packages/core/src/Runtime/OlliRuntime.ts
@@ -76,7 +76,7 @@ export class OlliRuntime {
 
     findTreeitems(this.rootDomNode, this, this.olliNodeLookup, undefined);
 
-    this.rootTreeItem = this.treeItems.find((ti) => ti.olliNode.nodeType === 'root')!;
+    this.rootTreeItem = this.treeItems[0];
     this.rootTreeItem.domNode.tabIndex = 0;
   }
 

--- a/packages/core/src/Runtime/OlliRuntime.ts
+++ b/packages/core/src/Runtime/OlliRuntime.ts
@@ -76,8 +76,6 @@ export class OlliRuntime {
 
     findTreeitems(this.rootDomNode, this, this.olliNodeLookup, undefined);
 
-    debugger;
-
     this.rootTreeItem = this.treeItems.find((ti) => ti.olliNode.nodeType === 'root')!;
     this.rootTreeItem.domNode.tabIndex = 0;
   }

--- a/packages/core/src/Runtime/OlliRuntimeTreeItem.ts
+++ b/packages/core/src/Runtime/OlliRuntimeTreeItem.ts
@@ -147,7 +147,7 @@ export class OlliRuntimeTreeItem {
         }
         break;
       case 'f':
-        openSelectionDialog(this.tree);
+        openSelectionDialog(this.olliNode, this.tree);
         break;
       case 'r':
         openTargetedNavigationDialog(this.tree);

--- a/packages/core/src/Structure/Types.ts
+++ b/packages/core/src/Structure/Types.ts
@@ -20,21 +20,13 @@ export interface OlliAnnotationNode {
 
 export type OlliNode = OlliGroupNode | OlliPredicateNode | OlliAnnotationNode;
 
-export type OlliNodeType =
-  | 'root'
-  | 'facet'
-  | 'layer'
-  | 'xAxis'
-  | 'yAxis'
-  | 'legend'
-  | 'filteredData'
-  | 'annotations'
-  | 'other';
+export type OlliNodeType = 'root' | 'view' | 'xAxis' | 'yAxis' | 'legend' | 'filteredData' | 'annotations' | 'other';
 
 export interface ElaboratedOlliNode {
   id: string;
   nodeType: OlliNodeType;
   specIndex?: number;
+  viewOp?: 'facet' | 'layer' | 'concat';
   fullPredicate: LogicalAnd<FieldPredicate>;
   parent?: ElaboratedOlliNode;
   children: ElaboratedOlliNode[];

--- a/packages/core/src/Structure/Types.ts
+++ b/packages/core/src/Structure/Types.ts
@@ -26,7 +26,7 @@ export interface ElaboratedOlliNode {
   id: string;
   nodeType: OlliNodeType;
   specIndex?: number;
-  viewOp?: 'facet' | 'layer' | 'concat';
+  viewType?: 'facet' | 'layer' | 'concat';
   fullPredicate: LogicalAnd<FieldPredicate>;
   parent?: ElaboratedOlliNode;
   children: ElaboratedOlliNode[];

--- a/packages/core/src/Structure/Types.ts
+++ b/packages/core/src/Structure/Types.ts
@@ -25,6 +25,7 @@ export type OlliNodeType = 'root' | 'facet' | 'xAxis' | 'yAxis' | 'legend' | 'fi
 export interface ElaboratedOlliNode {
   id: string;
   nodeType: OlliNodeType;
+  specIndex?: number;
   fullPredicate: LogicalAnd<FieldPredicate>;
   parent?: ElaboratedOlliNode;
   children: ElaboratedOlliNode[];

--- a/packages/core/src/Structure/Types.ts
+++ b/packages/core/src/Structure/Types.ts
@@ -20,7 +20,16 @@ export interface OlliAnnotationNode {
 
 export type OlliNode = OlliGroupNode | OlliPredicateNode | OlliAnnotationNode;
 
-export type OlliNodeType = 'root' | 'facet' | 'xAxis' | 'yAxis' | 'legend' | 'filteredData' | 'annotations' | 'other';
+export type OlliNodeType =
+  | 'root'
+  | 'facet'
+  | 'layer'
+  | 'xAxis'
+  | 'yAxis'
+  | 'legend'
+  | 'filteredData'
+  | 'annotations'
+  | 'other';
 
 export interface ElaboratedOlliNode {
   id: string;

--- a/packages/core/src/Structure/index.ts
+++ b/packages/core/src/Structure/index.ts
@@ -118,7 +118,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
       const elaborated = elaborateOlliNodes(spec, idx, nodes, data, { and: [] }, `${namespace}-${idx}`);
       return {
         id: `${namespace}-${idx}`,
-        nodeType: 'facet' as OlliNodeType,
+        nodeType: 'layer' as OlliNodeType,
         specIndex: idx,
         fullPredicate: { and: [] },
         description: new Map<string, string>(),

--- a/packages/core/src/Structure/index.ts
+++ b/packages/core/src/Structure/index.ts
@@ -72,7 +72,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
             return {
               id: childId,
               nodeType: nodeType === 'root' ? 'view' : 'filteredData',
-              viewOp: nodeType === 'root' ? 'facet' : undefined,
+              viewType: nodeType === 'root' ? 'facet' : undefined,
               specIndex,
               predicate: p,
               fullPredicate: childFullPred,
@@ -120,7 +120,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
       return {
         id: `${namespace}-${idx}`,
         nodeType: 'view' as OlliNodeType,
-        viewOp: olliSpec.operator,
+        viewType: olliSpec.operator,
         specIndex: idx,
         fullPredicate: { and: [] },
         description: new Map<string, string>(),

--- a/packages/core/src/Structure/infer.ts
+++ b/packages/core/src/Structure/infer.ts
@@ -1,8 +1,8 @@
-import { OlliAxis, OlliLegend, OlliSpec } from '../Types';
+import { OlliAxis, OlliLegend, UnitOlliSpec } from '../Types';
 import { getFieldDef } from '../util/data';
 import { OlliNode } from './Types';
 
-export function inferStructure(olliSpec: OlliSpec): OlliNode | OlliNode[] {
+export function inferStructure(olliSpec: UnitOlliSpec): OlliNode | OlliNode[] {
   function nodesFromGuides(axes: OlliAxis[], legends: OlliLegend[]): OlliNode[] {
     let nodes: OlliNode[] = [];
     if (axes) {

--- a/packages/core/src/Types.ts
+++ b/packages/core/src/Types.ts
@@ -1,7 +1,6 @@
 import { LogicalAnd } from 'vega-lite/src/logical';
 import { OlliNode } from './Structure/Types';
 import { FieldPredicate } from 'vega-lite/src/predicate';
-import { TimeUnit } from 'vega-lite/src/timeunit';
 
 export type OlliValue = string | number | Date;
 
@@ -57,11 +56,12 @@ export interface OlliLegend extends Guide {
 }
 
 export type MeasureType = 'quantitative' | 'ordinal' | 'nominal' | 'temporal';
+export type OlliTimeUnit = 'year' | 'month' | 'day' | 'date' | 'hours' | 'minutes' | 'seconds';
 
 export interface OlliFieldDef {
   field: string;
   type?: MeasureType; // optional, but will be inferred if not provided
-  timeUnit?: TimeUnit;
+  timeUnit?: OlliTimeUnit;
 }
 
 /**

--- a/packages/core/src/Types.ts
+++ b/packages/core/src/Types.ts
@@ -15,7 +15,7 @@ export type OlliMark = 'point' | 'bar' | 'line';
 /**
  * Spec describing a visualization
  */
-export interface OlliSpec {
+export interface UnitOlliSpec {
   // required: data and fields
   data: OlliDataset;
   // semi-required: specification of the fields/typings and structure (inferred if not provided)
@@ -32,6 +32,8 @@ export interface OlliSpec {
   title?: string;
   description?: string;
 }
+
+export type OlliSpec = UnitOlliSpec | UnitOlliSpec[];
 
 type Guide = {
   field: string;

--- a/packages/core/src/Types.ts
+++ b/packages/core/src/Types.ts
@@ -1,6 +1,7 @@
 import { LogicalAnd } from 'vega-lite/src/logical';
 import { OlliNode } from './Structure/Types';
 import { FieldPredicate } from 'vega-lite/src/predicate';
+import { TimeUnit } from 'vega-lite/src/timeunit';
 
 export type OlliValue = string | number | Date;
 
@@ -60,6 +61,7 @@ export type MeasureType = 'quantitative' | 'ordinal' | 'nominal' | 'temporal';
 export interface OlliFieldDef {
   field: string;
   type?: MeasureType; // optional, but will be inferred if not provided
+  timeUnit?: TimeUnit;
 }
 
 /**

--- a/packages/core/src/Types.ts
+++ b/packages/core/src/Types.ts
@@ -33,7 +33,16 @@ export interface UnitOlliSpec {
   description?: string;
 }
 
-export type OlliSpec = UnitOlliSpec | UnitOlliSpec[];
+export interface MultiOlliSpec {
+  operator: 'layer' | 'concat';
+  units: UnitOlliSpec[];
+}
+
+export const isMultiOlliSpec = (spec: OlliSpec): spec is MultiOlliSpec => {
+  return 'operator' in spec;
+};
+
+export type OlliSpec = UnitOlliSpec | MultiOlliSpec;
 
 type Guide = {
   field: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { UnitOlliSpec } from './Types';
+import { OlliSpec } from './Types';
 import { ElaboratedOlliNode } from './Structure/Types';
 import { OlliRuntime, RuntimeCallbacks } from './Runtime/OlliRuntime';
 import { updateGlobalStateOnInitialRender } from './util/globalState';
@@ -16,8 +16,7 @@ export type OlliConfigOptions = {
   onSelection?: (predicate: LogicalComposition<FieldPredicate>) => void;
 };
 
-export function olli(olliSpec: UnitOlliSpec, config?: OlliConfigOptions): HTMLElement {
-  console.log(olliSpec);
+export function olli(olliSpec: OlliSpec, config?: OlliConfigOptions): HTMLElement {
   olliSpec = elaborateSpec(olliSpec);
 
   const renderContainer: HTMLElement = document.createElement('div');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { OlliSpec } from './Types';
+import { UnitOlliSpec } from './Types';
 import { ElaboratedOlliNode } from './Structure/Types';
 import { OlliRuntime, RuntimeCallbacks } from './Runtime/OlliRuntime';
 import { updateGlobalStateOnInitialRender } from './util/globalState';
@@ -16,7 +16,8 @@ export type OlliConfigOptions = {
   onSelection?: (predicate: LogicalComposition<FieldPredicate>) => void;
 };
 
-export function olli(olliSpec: OlliSpec, config?: OlliConfigOptions): HTMLElement {
+export function olli(olliSpec: UnitOlliSpec, config?: OlliConfigOptions): HTMLElement {
+  console.log(olliSpec);
   olliSpec = elaborateSpec(olliSpec);
 
   const renderContainer: HTMLElement = document.createElement('div');

--- a/packages/core/src/util/bin.ts
+++ b/packages/core/src/util/bin.ts
@@ -12,7 +12,7 @@ export function getBins(
   domainFilter?: LogicalComposition<FieldPredicate>
 ): [number, number][] {
   const fieldDef = getFieldDef(field, fields);
-  const domain = getDomain(field, data, domainFilter);
+  const domain = getDomain(fieldDef, data, domainFilter);
   const bins = [];
   let ticks;
   if (fieldDef.type === 'temporal') {

--- a/packages/core/src/util/data.ts
+++ b/packages/core/src/util/data.ts
@@ -19,7 +19,6 @@ export function getDomain(
       .forEach((v) => {
         if (v instanceof Date) {
           const time_val = dateToTimeUnit(v, fieldDef.timeUnit);
-          console.log('time_val', time_val);
           if (!unique_time_vals.has(time_val)) {
             unique_time_vals.add(time_val);
             unique_vals.add(v);
@@ -33,7 +32,6 @@ export function getDomain(
         unique_vals.add(v);
       });
   }
-  console.log('unique', [...unique_vals]);
   return [...unique_vals].filter((x) => x !== null && x !== undefined).sort((a: any, b: any) => a - b);
 }
 

--- a/packages/core/src/util/data.ts
+++ b/packages/core/src/util/data.ts
@@ -26,10 +26,19 @@ export function getDomain(
         }
       });
   } else {
+    const unique_time_vals = new Set<number>();
     dataset
       .map((d) => d[fieldDef.field])
       .forEach((v) => {
-        unique_vals.add(v);
+        if (v instanceof Date) {
+          const time_val = v.getTime();
+          if (!unique_time_vals.has(time_val)) {
+            unique_time_vals.add(time_val);
+            unique_vals.add(v);
+          }
+        } else {
+          unique_vals.add(v);
+        }
       });
   }
   return [...unique_vals].filter((x) => x !== null && x !== undefined).sort((a: any, b: any) => a - b);

--- a/packages/core/src/util/data.ts
+++ b/packages/core/src/util/data.ts
@@ -2,20 +2,38 @@ import { OlliDataset, OlliFieldDef, UnitOlliSpec, OlliValue } from '../Types';
 import { selectionTest } from './selection';
 import { LogicalComposition } from 'vega-lite/src/logical';
 import { FieldPredicate } from 'vega-lite/src/predicate';
+import { dateToTimeUnit } from './values';
 
 export function getDomain(
-  field: string,
+  fieldDef: OlliFieldDef,
   data: OlliDataset,
   predicate?: LogicalComposition<FieldPredicate>
 ): OlliValue[] {
   const unique_vals = new Set<OlliValue>();
   const dataset = predicate ? selectionTest(data, predicate) : data;
   // TODO account for domain overrides in the field def
-  dataset
-    .map((d) => d[field])
-    .forEach((v) => {
-      unique_vals.add(v);
-    });
+  if (fieldDef.timeUnit) {
+    const unique_time_vals = new Set<string>();
+    dataset
+      .map((d) => d[fieldDef.field])
+      .forEach((v) => {
+        if (v instanceof Date) {
+          const time_val = dateToTimeUnit(v, fieldDef.timeUnit);
+          console.log('time_val', time_val);
+          if (!unique_time_vals.has(time_val)) {
+            unique_time_vals.add(time_val);
+            unique_vals.add(v);
+          }
+        }
+      });
+  } else {
+    dataset
+      .map((d) => d[fieldDef.field])
+      .forEach((v) => {
+        unique_vals.add(v);
+      });
+  }
+  console.log('unique', [...unique_vals]);
   return [...unique_vals].filter((x) => x !== null && x !== undefined).sort((a: any, b: any) => a - b);
 }
 

--- a/packages/core/src/util/data.ts
+++ b/packages/core/src/util/data.ts
@@ -1,4 +1,4 @@
-import { OlliDataset, OlliFieldDef, OlliSpec, OlliValue } from '../Types';
+import { OlliDataset, OlliFieldDef, UnitOlliSpec, OlliValue } from '../Types';
 import { selectionTest } from './selection';
 import { LogicalComposition } from 'vega-lite/src/logical';
 import { FieldPredicate } from 'vega-lite/src/predicate';

--- a/packages/core/src/util/elaborate.ts
+++ b/packages/core/src/util/elaborate.ts
@@ -1,13 +1,16 @@
 import { inferStructure } from '../Structure/infer';
-import { OlliSpec, UnitOlliSpec } from '../Types';
+import { OlliSpec, UnitOlliSpec, isMultiOlliSpec } from '../Types';
 import { typeInference } from './types';
 
 // fills in default values for missing spec fields
 export function elaborateSpec(olliSpec: OlliSpec): OlliSpec {
-  if (Array.isArray(olliSpec)) {
-    return olliSpec.map((spec) => {
-      return elaborateUnitSpec(spec);
-    });
+  if (isMultiOlliSpec(olliSpec)) {
+    return {
+      ...olliSpec,
+      units: olliSpec.units.map((spec) => {
+        return elaborateUnitSpec(spec);
+      }),
+    };
   } else {
     return elaborateUnitSpec(olliSpec);
   }

--- a/packages/core/src/util/elaborate.ts
+++ b/packages/core/src/util/elaborate.ts
@@ -1,9 +1,19 @@
 import { inferStructure } from '../Structure/infer';
-import { OlliSpec } from '../Types';
+import { OlliSpec, UnitOlliSpec } from '../Types';
 import { typeInference } from './types';
 
 // fills in default values for missing spec fields
 export function elaborateSpec(olliSpec: OlliSpec): OlliSpec {
+  if (Array.isArray(olliSpec)) {
+    return olliSpec.map((spec) => {
+      return elaborateUnitSpec(spec);
+    });
+  } else {
+    return elaborateUnitSpec(olliSpec);
+  }
+}
+
+function elaborateUnitSpec(olliSpec: UnitOlliSpec): UnitOlliSpec {
   // if fields not provided, use all fields in data
   olliSpec.fields =
     olliSpec.fields ||

--- a/packages/core/src/util/selection.ts
+++ b/packages/core/src/util/selection.ts
@@ -1,7 +1,7 @@
 import { isDate, toNumber, isArray, inrange } from 'vega';
 import { LogicalAnd, LogicalComposition } from 'vega-lite/src/logical';
 import { FieldPredicate, FieldEqualPredicate } from 'vega-lite/src/predicate';
-import { OlliFieldDef, OlliDataset, OlliDatum, OlliValue, UnitOlliSpec } from '../Types';
+import { OlliFieldDef, OlliDataset, OlliDatum, OlliValue } from '../Types';
 import { serializeValue } from './values';
 import { getDomain, getFieldDef } from './data';
 import { getBinPredicates } from './bin';
@@ -167,8 +167,8 @@ export function datumToPredicate(datum: OlliDatum, fieldDefs: OlliFieldDef[]): L
 
 export function fieldToPredicates(field: string, data: OlliDataset, fields: OlliFieldDef[]): FieldPredicate[] {
   const fieldDef = getFieldDef(field, fields);
-  if (fieldDef.type === 'nominal' || fieldDef.type === 'ordinal') {
-    const domain = getDomain(field, data);
+  if (fieldDef.type === 'nominal' || fieldDef.type === 'ordinal' || fieldDef.timeUnit) {
+    const domain = getDomain(fieldDef, data);
     return domain.map((value) => {
       return {
         field: field,

--- a/packages/core/src/util/selection.ts
+++ b/packages/core/src/util/selection.ts
@@ -1,7 +1,7 @@
 import { isDate, toNumber, isArray, inrange } from 'vega';
 import { LogicalAnd, LogicalComposition } from 'vega-lite/src/logical';
 import { FieldPredicate, FieldEqualPredicate } from 'vega-lite/src/predicate';
-import { OlliFieldDef, OlliDataset, OlliDatum, OlliValue, OlliSpec } from '../Types';
+import { OlliFieldDef, OlliDataset, OlliDatum, OlliValue, UnitOlliSpec } from '../Types';
 import { serializeValue } from './values';
 import { getDomain, getFieldDef } from './data';
 import { getBinPredicates } from './bin';

--- a/packages/core/src/util/values.ts
+++ b/packages/core/src/util/values.ts
@@ -3,9 +3,6 @@ import { isString } from 'vega';
 import { OlliFieldDef, OlliTimeUnit, OlliValue } from '../Types';
 
 export const fmtValue = (value: OlliValue, fieldDef: OlliFieldDef): string => {
-  if (fieldDef.timeUnit && !(value instanceof Date)) {
-    value = new Date(value);
-  }
   if (value instanceof Date) {
     return dateToTimeUnit(value, fieldDef.timeUnit);
   } else if (typeof value !== 'string' && !isNaN(value) && value % 1 != 0) {

--- a/packages/core/src/util/values.ts
+++ b/packages/core/src/util/values.ts
@@ -1,7 +1,6 @@
 import { isNumeric as vlIsNumeric } from 'vega-lite';
 import { isString } from 'vega';
-import { OlliFieldDef, OlliValue } from '../Types';
-import { TimeUnit } from 'vega-lite/src/timeunit';
+import { OlliFieldDef, OlliTimeUnit, OlliValue } from '../Types';
 
 export const fmtValue = (value: OlliValue, fieldDef: OlliFieldDef): string => {
   if (fieldDef.timeUnit && !(value instanceof Date)) {
@@ -36,7 +35,7 @@ export function isNumeric(value: string): boolean {
   return vlIsNumeric(value.replaceAll(',', ''));
 }
 
-export function dateToTimeUnit(date: Date, timeUnit: TimeUnit): string {
+export function dateToTimeUnit(date: Date, timeUnit: OlliTimeUnit): string {
   let opts;
   switch (timeUnit) {
     case 'year':

--- a/packages/core/src/util/values.ts
+++ b/packages/core/src/util/values.ts
@@ -8,28 +8,7 @@ export const fmtValue = (value: OlliValue, fieldDef: OlliFieldDef): string => {
     value = new Date(value);
   }
   if (value instanceof Date) {
-    if (fieldDef?.timeUnit) {
-      let opts;
-      switch (fieldDef.timeUnit) {
-        case 'year':
-          opts = { year: 'numeric' };
-          break;
-        case 'month':
-          opts = { month: 'short' };
-          break;
-        case 'day':
-          opts = { day: 'numeric' };
-          break;
-        default:
-          opts = { year: 'numeric', month: 'short', day: 'numeric' };
-      }
-      return value.toLocaleString('en-US', opts);
-    }
-    return value.toLocaleString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
+    return dateToTimeUnit(value, fieldDef.timeUnit);
   } else if (typeof value !== 'string' && !isNaN(value) && value % 1 != 0) {
     return Number(value).toFixed(2);
   }
@@ -67,7 +46,19 @@ export function dateToTimeUnit(date: Date, timeUnit: TimeUnit): string {
       opts = { month: 'short' };
       break;
     case 'day':
+      opts = { weekday: 'short' };
+      break;
+    case 'date':
       opts = { day: 'numeric' };
+      break;
+    case 'hours':
+      opts = { hour: 'numeric' };
+      break;
+    case 'minutes':
+      opts = { minute: 'numeric' };
+      break;
+    case 'seconds':
+      opts = { second: 'numeric' };
       break;
     default:
       opts = { year: 'numeric', month: 'short', day: 'numeric' };

--- a/packages/core/src/util/values.ts
+++ b/packages/core/src/util/values.ts
@@ -1,9 +1,30 @@
 import { isNumeric as vlIsNumeric } from 'vega-lite';
 import { isString } from 'vega';
-import { OlliValue } from '../Types';
+import { OlliFieldDef, OlliValue } from '../Types';
+import { TimeUnit } from 'vega-lite/src/timeunit';
 
-export const fmtValue = (value: OlliValue): string => {
+export const fmtValue = (value: OlliValue, fieldDef: OlliFieldDef): string => {
+  if (fieldDef.timeUnit && !(value instanceof Date)) {
+    value = new Date(value);
+  }
   if (value instanceof Date) {
+    if (fieldDef?.timeUnit) {
+      let opts;
+      switch (fieldDef.timeUnit) {
+        case 'year':
+          opts = { year: 'numeric' };
+          break;
+        case 'month':
+          opts = { month: 'short' };
+          break;
+        case 'day':
+          opts = { day: 'numeric' };
+          break;
+        default:
+          opts = { year: 'numeric', month: 'short', day: 'numeric' };
+      }
+      return value.toLocaleString('en-US', opts);
+    }
     return value.toLocaleString('en-US', {
       year: 'numeric',
       month: 'short',
@@ -34,4 +55,23 @@ export function datestampToTime(datestamp: string | string[]) {
 
 export function isNumeric(value: string): boolean {
   return vlIsNumeric(value.replaceAll(',', ''));
+}
+
+export function dateToTimeUnit(date: Date, timeUnit: TimeUnit): string {
+  let opts;
+  switch (timeUnit) {
+    case 'year':
+      opts = { year: 'numeric' };
+      break;
+    case 'month':
+      opts = { month: 'short' };
+      break;
+    case 'day':
+      opts = { day: 'numeric' };
+      break;
+    default:
+      opts = { year: 'numeric', month: 'short', day: 'numeric' };
+      break;
+  }
+  return date.toLocaleString('en-US', opts);
 }

--- a/packages/core/src/util/values.ts
+++ b/packages/core/src/util/values.ts
@@ -36,32 +36,33 @@ export function isNumeric(value: string): boolean {
 }
 
 export function dateToTimeUnit(date: Date, timeUnit: OlliTimeUnit): string {
-  let opts;
-  switch (timeUnit) {
-    case 'year':
-      opts = { year: 'numeric' };
-      break;
-    case 'month':
-      opts = { month: 'short' };
-      break;
-    case 'day':
-      opts = { weekday: 'short' };
-      break;
-    case 'date':
-      opts = { day: 'numeric' };
-      break;
-    case 'hours':
-      opts = { hour: 'numeric' };
-      break;
-    case 'minutes':
-      opts = { minute: 'numeric' };
-      break;
-    case 'seconds':
-      opts = { second: 'numeric' };
-      break;
-    default:
-      opts = { year: 'numeric', month: 'short', day: 'numeric' };
-      break;
+  if (!timeUnit) {
+    return date.toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+  const opts = {};
+  if (timeUnit.includes('year')) {
+    opts['year'] = 'numeric';
+  }
+  if (timeUnit.includes('month')) {
+    opts['month'] = 'short';
+  }
+  if (timeUnit.includes('day')) {
+    opts['weekday'] = 'short';
+  }
+  if (timeUnit.includes('date')) {
+    opts['day'] = 'numeric';
+  }
+  if (timeUnit.includes('hours')) {
+    opts['hour'] = 'numeric';
+  }
+  if (timeUnit.includes('minutes')) {
+    opts['minute'] = 'numeric';
+  }
+  if (timeUnit.includes('seconds')) {
+    opts['second'] = 'numeric';
+  }
+  if (!Object.keys(opts).length) {
+    return date.toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
   }
   return date.toLocaleString('en-US', opts);
 }


### PR DESCRIPTION
This PR adds support for layer and concat specs in Vega-lite. It also adds support for timeUnit.

Changes that are good to know for everyone:
- what was previously known as `OlliSpec` is now a `UnitOlliSpec`. The new definition of `OlliSpec` is `UnitOlliSpec | MultiOlliSpec`
- to check whether an `OlliSpec` is a unit or a multi, use `isMultiOlliSpec`
- for a node that is inside of a multi-view, use `getSpecForNode` to get the corresponding `UnitOlliSpec`

New examples:
- Layered chart
- Concatenated chart (broken pending support for binning, but the concat part works)

Old examples replaced with specs that use timeUnit:
- Aggregate bar chart
- Area chart

Relevant issues:
https://github.com/mitvis/olli/issues/95
https://github.com/mitvis/olli/issues/91