### PR TITLE
Add backend capability to reorder and change verbosity

### DIFF
--- a/packages/core/src/Customization/Types.ts
+++ b/packages/core/src/Customization/Types.ts
@@ -1,5 +1,10 @@
 export const tokenType = ['name', 'index', 'type', 'children', 'data', 'size', 'level', 'parent', 'quartile', 'aggregate', 'instructions'] as const;
 export type TokenType = typeof tokenType[number];
 
+export enum tokenLength {
+  Short,
+  Long
+}
+
 /* Intended to grow in complexity as we expand customization options */
-export type CustomizeSetting = {[k in TokenType]: boolean};
+export type CustomizeSetting = [string, tokenLength][]

--- a/packages/core/src/Customization/data.ts
+++ b/packages/core/src/Customization/data.ts
@@ -1,4 +1,7 @@
-import { CustomizeSetting } from './Types';
+import { CustomizeSetting, tokenLength } from './Types';
+
+const Short = tokenLength.Short
+const Long = tokenLength.Long
 
 // Note: when putting a number before a quotation mark, add a space or else VoiceOver will read 
 // the quotation mark as feet/inches
@@ -16,16 +19,16 @@ export const tokenDescs = {
   'instructions': 'Instructions for accessing data table',
 }
 
-export let defaultSetting: CustomizeSetting = {
-  'name': true,
-  'index': true,
-  'type': true,
-  'children': true,
-  'data': true,
-  'size': true,
-  'level': true,
-  'parent': true,
-  'quartile': true,
-  'aggregate': true,
-  'instructions': true,
-}
+export let defaultSetting: CustomizeSetting = [
+  ['name', Long],
+  ['index', Long],
+  ['type', Long],
+  ['children', Long],
+  ['data', Long],
+  ['size', Long],
+  ['level', Long],
+  ['parent', Long],
+  ['quartile', Long],
+  ['aggregate', Long],
+  ['instructions', Long],
+]

--- a/packages/core/src/Structure/Types.ts
+++ b/packages/core/src/Structure/Types.ts
@@ -32,7 +32,7 @@ export interface ElaboratedOlliNode {
   children: ElaboratedOlliNode[];
   groupby?: string;
   predicate?: FieldPredicate;
-  description: Map<string, string>;
+  description: Map<string, string[]>;
   level: number;
 }
 

--- a/packages/core/src/Structure/index.ts
+++ b/packages/core/src/Structure/index.ts
@@ -26,7 +26,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
       id: namespace,
       nodeType: 'root',
       fullPredicate: { and: [] },
-      description: new Map<string, string>(),
+      description: new Map<string, string[]>(),
       children: nodes,
       level: 1,
     };
@@ -74,7 +74,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
           nodeType,
           specIndex,
           groupby: node.groupby,
-          description: new Map<string, string>(),
+          description: new Map<string, string[]>(),
           children: childPreds.map((p, childIdx) => {
             const childFullPred = {
               and: [...fullPredicate.and, p],
@@ -87,7 +87,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
               specIndex,
               predicate: p,
               fullPredicate: childFullPred,
-              description: new Map<string, string>(),
+              description: new Map<string, string[]>(),
               children: elaborateOlliNodes(olliSpec, specIndex, node.children, data, childFullPred, childId, level + 2),
               level: level + 2,
             };
@@ -106,7 +106,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
           specIndex,
           fullPredicate: nextFullPred,
           predicate,
-          description: new Map<string, string>(),
+          description: new Map<string, string[]>(),
           children: elaborateOlliNodes(olliSpec, specIndex, node.children, data, nextFullPred, nextId, level + 1),
           level: level + 1,
         };
@@ -117,7 +117,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
           fullPredicate,
           nodeType: 'annotations',
           specIndex,
-          description: new Map<string, string>(),
+          description: new Map<string, string[]>(),
           children: elaborateOlliNodes(olliSpec, specIndex, node.annotations, data, fullPredicate, id, level + 1),
           level: level + 1,
         };
@@ -138,7 +138,7 @@ export function olliSpecToTree(olliSpec: OlliSpec): ElaboratedOlliNode {
         viewType: olliSpec.operator,
         specIndex: idx,
         fullPredicate: { and: [] },
-        description: new Map<string, string>(),
+        description: new Map<string, string[]>(),
         children: elaborated,
         level: 1,
       };


### PR DESCRIPTION
This PR does *not* add a UI for token reordering, nor does it have well-written long and short verbosities for each token. However, it adds the backend capability necessary to do those two things.